### PR TITLE
apps/home: add title of simple page to panel

### DIFF
--- a/apps/home/models.py
+++ b/apps/home/models.py
@@ -92,7 +92,12 @@ class SimplePage(Page):
         StreamFieldPanel('body_en'),
     ]
 
+    common_panels = [
+        FieldPanel('title'),
+    ]
+
     edit_handler = TabbedInterface([
+        ObjectList(common_panels, heading='Common'),
         ObjectList(de_content_panels, heading='German'),
         ObjectList(en_content_panels, heading='English'),
     ])


### PR DESCRIPTION
This fixes the error when trying to add a simple page.
For a fresh DB, this workd right away.
For the older one where I already tried to add a simple page, I got a new error (`AttributeError: 'NoneType' object has no attribute '_inc_path'`) and had to do:
`python manage.py fixtree`