### PR TITLE
Implement full-text search with elasticsearch

### DIFF
--- a/apps/contrib/translations.py
+++ b/apps/contrib/translations.py
@@ -31,3 +31,14 @@ class TranslatedField(object):
             return de_ls
         else:
             return de
+
+
+def get_search_fields():
+    fields = [
+        '*page_title_',
+        '*page_intro_'
+        '*subtitle_',
+        '*body_',
+    ]
+    lang = translation.get_language()
+    return [f + lang for f in fields]

--- a/apps/contrib/views.py
+++ b/apps/contrib/views.py
@@ -1,0 +1,37 @@
+from django.views.generic import ListView
+from wagtail.core.models import Page
+from wagtail.search.backends import get_search_backend
+
+from apps.contrib.translations import get_search_fields
+
+
+class CustomQueryCompiler:
+    queryset = Page.objects.all()
+
+
+class SearchResultsView(ListView):
+    template_name = 'search_results.html'
+
+    def get_queryset(self):
+        sb = get_search_backend()
+        sb.query_compiler = CustomQueryCompiler()
+        # needs to be set otherwise _get_results_from_hits will fail
+        sb._score_field = False
+        query = self.request.GET.get('q')
+        res = sb.es.search(index="wagtail__wagtailcore_page",
+                           _source=False,
+                           size=100, stored_fields="pk",
+                           query={"multi_match":
+                                  {"query": query,
+                                   "fields": get_search_fields(),
+                                   "type": "best_fields",
+                                   "operator": "OR",
+                                   "slop": 0,
+                                   "prefix_length": 0,
+                                   "max_expansions": 50,
+                                   "zero_terms_query": "NONE",
+                                   "auto_generate_synonyms_" +
+                                   "phrase_query": True,
+                                   "boost": 1.0}})
+        res = sb.results_class._get_results_from_hits(sb, res['hits']['hits'])
+        return res

--- a/apps/gruenbuch/models.py
+++ b/apps/gruenbuch/models.py
@@ -8,6 +8,7 @@ from wagtail.core import blocks
 from wagtail.core import fields
 from wagtail.core.models import Page
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 
 from apps.contrib.mixins import TeaserFieldsMixin
 from apps.contrib.translations import TranslatedField
@@ -106,12 +107,6 @@ class GruenbuchDetailPage(Page):
     body_en = fields.StreamField(page_blocks, blank=True)
     body_de_ls = fields.StreamField(page_blocks, blank=True)
 
-    body = TranslatedField(
-        'body_de',
-        'body_en',
-        'body_de_ls',
-    )
-
     page_title = TranslatedField(
         'page_title_de',
         'page_title_en',
@@ -122,6 +117,12 @@ class GruenbuchDetailPage(Page):
         'subtitle_de',
         'subtitle_en',
         'subtitle_de_ls',
+    )
+
+    body = TranslatedField(
+        'body_de',
+        'body_en',
+        'body_de_ls',
     )
 
     de_content_panels = [
@@ -181,3 +182,22 @@ class GruenbuchDetailPage(Page):
             return ''
 
     subpage_types = []
+
+    search_fields = Page.search_fields + [
+        index.SearchField('page_title_de',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('page_title_de_ls',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('page_title_en',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('subtitle_de',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('subtitle_de_ls',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('subtitle_en',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_de', es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_de_ls',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_en', es_extra={'analyzer': 'ngram_analyzer'}),
+    ]

--- a/apps/home/models.py
+++ b/apps/home/models.py
@@ -8,6 +8,7 @@ from wagtail.core import blocks
 from wagtail.core import fields
 from wagtail.core.models import Page
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 
 from apps.contrib.mixins import TeaserFieldsMixin
 from apps.contrib.translations import TranslatedField
@@ -87,9 +88,21 @@ class HomePage(Page):
                      'apps_forms.ContactFormPage',
                      'apps_forms.ParticipationFormPage']
 
+    search_fields = Page.search_fields + [
+        index.SearchField('subtitle_de',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('subtitle_en',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('subtitle_de_ls',
+                          es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_de', es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_en', es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_de_ls',
+                          es_extra={'analyzer': 'ngram_analyzer'})
+    ]
+
 
 class OverviewPage(Page):
-
     teaser_blocks = [
         ('teaser_centered', apps_blocks.TeaserBlockCentered()),
         ('teaser_two_columns', apps_blocks.TeaserBlockTwoColumns()),
@@ -232,6 +245,13 @@ class DetailPage(Page, TeaserFieldsMixin):
 
     subpage_types = []
 
+    search_fields = Page.search_fields + [
+        index.SearchField('body_de', es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_en', es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_de_ls',
+                          es_extra={'analyzer': 'ngram_analyzer'})
+    ]
+
 
 class SimplePage(Page):
     page_blocks = [
@@ -288,3 +308,10 @@ class SimplePage(Page):
     ])
 
     subpage_types = []
+
+    search_fields = Page.search_fields + [
+        index.SearchField('body_de', es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_en', es_extra={'analyzer': 'ngram_analyzer'}),
+        index.SearchField('body_de_ls',
+                          es_extra={'analyzer': 'ngram_analyzer'})
+    ]

--- a/digitalstrategie/settings/base.py
+++ b/digitalstrategie/settings/base.py
@@ -178,3 +178,14 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
         'WIDGET': 'wagtail.admin.rich_text.HalloRichTextArea'
     }
 }
+
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.search.backends.elasticsearch7',
+        'URLS': ['http://localhost:9200'],
+        'INDEX': 'wagtail',
+        'TIMEOUT': 5,
+        'OPTIONS': {},
+        'INDEX_SETTINGS': {}
+    }
+}

--- a/digitalstrategie/templates/includes/header.html
+++ b/digitalstrategie/templates/includes/header.html
@@ -116,7 +116,7 @@
                     </div>
                     <div class="overlay__body">
                         <div class="search-container">
-                            <form class="search-form">
+                            <form class="search-form" action="{% url 'search' %}" method="get">
                                 <label for="searchFormInput_q">{% trans 'Search on the website "Digitalstrategie Berlin"' %}</label>
                                 <div class="form-group">
                                     <input name="q" class="form-control" id="searchFormInput_q" placeholder="Suchbegriff">

--- a/digitalstrategie/templates/search_results.html
+++ b/digitalstrategie/templates/search_results.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block content %}
+    <div class="search-container">
+        <form class="search-form" action="{% url 'search' %}" method="get">
+            <div class="form-group">
+                <input name="q" class="form-control" id="searchFormInput_q" placeholder="Suchbegriff">
+                <button type="submit" class="button"><i class="fas fa-search" aria-hidden="true"></i> <span>Suchen</span></button>
+            </div>
+        </form>
+    </div>
+
+    {% if object_list %}
+        <ul>
+            {% for result in object_list %}
+                <li>
+                    <h4><a href="{% pageurl result %}">{{ result }}</a></h4>
+                    {% if result.specific.body %}
+                        {{ result.specific.body|safe|slice:300 }}
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% elif request.GET.q %}
+        No results found
+    {% endif %}
+{% endblock %}

--- a/digitalstrategie/urls.py
+++ b/digitalstrategie/urls.py
@@ -8,6 +8,8 @@ from wagtail.contrib.sitemaps.views import sitemap as wagtail_sitemap
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
+from apps.contrib.views import SearchResultsView
+
 urlpatterns = [
     url(r'^django-admin/', admin.site.urls),
     url(r'^admin/', include(wagtailadmin_urls)),
@@ -17,6 +19,7 @@ urlpatterns = [
     url(r'^robots\.txt$', TemplateView.as_view(
         template_name='robots.txt',
         content_type="text/plain"), name="robots_file"),
+    url(r'^search/', SearchResultsView.as_view(), name="search"),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+DJANGO_SETTINGS_MODULE=digitalstrategie.settings.test
 testpaths=tests
 python_files=
     tests.py

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,4 @@ sentry-sdk==1.4.2
 wagtail==2.14.1
 whitenoise==5.3.0
 psycopg2-binary==2.9.1
+elasticsearch==7.15.1

--- a/tests/contrib/test_translations.py
+++ b/tests/contrib/test_translations.py
@@ -1,0 +1,15 @@
+from django.utils import translation
+
+from apps.contrib.translations import get_search_fields
+
+
+def test_get_search_fields():
+    with translation.override("en"):
+        fields = get_search_fields()
+        assert all(map(lambda field: field.endswith("_en"), fields))
+    with translation.override("de"):
+        fields = get_search_fields()
+        assert all(map(lambda field: field.endswith("_de"), fields))
+    with translation.override("de_ls"):
+        fields = get_search_fields()
+        assert all(map(lambda field: field.endswith("_de-ls"), fields))


### PR DESCRIPTION
@sabinammm So this is what I came up with so far.. using wagtail postgres search backend, then adding (most of) the page fields to search index and a very simple view that lists all search results.
To do/open questions 

- [ ] what do we do with the translated fields -> eg only search german fields on german site
- [ ] should teaser fields be added to search
- [ ] should form fields be added to search
- [ ] optimize search -> order
- [ ] style result page
- [ ] is this enough or do we need js for immediate display of results
- [ ] ...