### PR TITLE
stylelint: adding dependency, adjusting scss files and stylelint config

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["stylelint-config-standard-scss"],
   "rules": {
     "color-hex-case": "lower",
     "color-hex-length": "short",
@@ -47,7 +48,12 @@
     "indentation": 4,
     "max-empty-lines": 2,
     "max-nesting-depth": 2,
-    "no-extra-semicolons": true
+    "no-extra-semicolons": true,
+    "scss/dollar-variable-pattern": "^([a-z][a-z0-9]*)((-|--|_|__)[a-z0-9]+)*$",
+    "selector-class-pattern": "^([a-z][a-z0-9]*)((-|--|_|__)[a-z0-9]+)*$",
+    "declaration-colon-newline-after": null,
+    "scss/at-extend-no-missing-placeholder": null,
+    "alpha-value-notation": null
   },
   "ignoreFiles": [
     "**/_variables.scss"

--- a/digitalstrategie/assets/scss/_base.scss
+++ b/digitalstrategie/assets/scss/_base.scss
@@ -4,7 +4,7 @@
     box-sizing: inherit;
 }
 
-//fixes horizontal scroll issue cause by header+footer width
+// fixes horizontal scroll issue cause by header+footer width
 html {
     overflow-y: scroll;
     background-color: $body-bg;
@@ -13,9 +13,7 @@ html {
     font-family: $font-family-base;
     font-family: $font-family-sans-serif;
     line-height: 1.4;
-
     scroll-behavior: smooth;
-
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
@@ -63,11 +61,11 @@ h5 {
 // mobile sizes
 @media screen and (max-width: $breakpoint-md-down) {
     h1 {
-        font-size: $mobile-headline-size*$h1-font-size;
+        font-size: $mobile-headline-size * $h1-font-size;
     }
 
     h2 {
-        font-size: $mobile-headline-size*$h2-font-size;
+        font-size: $mobile-headline-size * $h2-font-size;
     }
 
     h3,

--- a/digitalstrategie/assets/scss/_core-variables.scss
+++ b/digitalstrategie/assets/scss/_core-variables.scss
@@ -1,13 +1,12 @@
 $mobile-headline-size: 0.8 !default;
-
 $spacer: 1rem !default;
 
 // use for min-width media-queries
-$breakpoint-xs: map-get($grid-breakpoints, "sm") !default;
-$breakpoint-sm: map-get($grid-breakpoints, "md") !default;
-$breakpoint-md: map-get($grid-breakpoints, "lg") !default;
-$breakpoint-lg: map-get($grid-breakpoints, "xl") !default;
-$breakpoint-xl: map-get($grid-breakpoints, "xxl") !default;
+$breakpoint-xs: map.get($grid-breakpoints, "sm") !default;
+$breakpoint-sm: map.get($grid-breakpoints, "md") !default;
+$breakpoint-md: map.get($grid-breakpoints, "lg") !default;
+$breakpoint-lg: map.get($grid-breakpoints, "xl") !default;
+$breakpoint-xl: map.get($grid-breakpoints, "xxl") !default;
 
 // use for max-width media queries
 $breakpoint-xs-down: $breakpoint-xs - 0.1px !default;
@@ -17,4 +16,4 @@ $breakpoint-lg-down: $breakpoint-lg - 0.1px !default;
 $breakpoint-xl-down: $breakpoint-xl - 0.1px !default;
 
 // light accordion icon
-$accordion-button-icon--light:   url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23fff'><path fill-rule='evenodd' d='M8 0a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 0 1 0-2h6V1a1 1 0 0 1 1-1z'/></svg>");
+$accordion-button-icon--light: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23fff'><path fill-rule='evenodd' d='M8 0a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 0 1 0-2h6V1a1 1 0 0 1 1-1z'/></svg>");

--- a/digitalstrategie/assets/scss/_fonts.scss
+++ b/digitalstrategie/assets/scss/_fonts.scss
@@ -1,18 +1,19 @@
 @font-face {
-    font-family: 'BerlinType';
-    src: url('../fonts/BerlinTypeWeb-Regular.eot'); /* IE9 Compat Modes */
-    src: url('../fonts/BerlinTypeWeb-Regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('../fonts/BerlinTypeWeb-Regular.woff2') format('woff2'), /* Super Modern Browsers */
-        url('../fonts/BerlinTypeWeb-Regular.woff') format('woff'), /* Pretty Modern Browsers */
-        url('../fonts/BerlinTypeOffice-Regular.ttf')  format('truetype'), /* Safari, Android, iOS */
+    font-family: "BerlinType";
+    src: url("../fonts/BerlinTypeWeb-Regular.eot"); /* IE9 Compat Modes */
+    src: url("../fonts/BerlinTypeWeb-Regular.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+        url("../fonts/BerlinTypeWeb-Regular.woff2") format("woff2"), /* Super Modern Browsers */
+        url("../fonts/BerlinTypeWeb-Regular.woff") format("woff"), /* Pretty Modern Browsers */
+        url("../fonts/BerlinTypeOffice-Regular.ttf")  format("truetype"), /* Safari, Android, iOS */
 }
 
 @font-face {
-    font-family: 'BerlinType';
-    src: url('../fonts/BerlinTypeWeb-Bold.eot'); /* IE9 Compat Modes */
-    src: url('../fonts/BerlinTypeWeb-Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-        url('../fonts/BerlinTypeWeb-Bold.woff2') format('woff2'), /* Super Modern Browsers */
-        url('../fonts/BerlinTypeWeb-Bold.woff') format('woff'), /* Pretty Modern Browsers */
-        url('../fonts/BerlinTypeOffice-Bold.ttf')  format('truetype'); /* Safari, Android, iOS */
+    font-family: "BerlinType";
+    src: url("../fonts/BerlinTypeWeb-Bold.eot"); /* IE9 Compat Modes */
+    src: url("../fonts/BerlinTypeWeb-Bold.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+        url("../fonts/BerlinTypeWeb-Bold.woff2") format("woff2"), /* Super Modern Browsers */
+        url("../fonts/BerlinTypeWeb-Bold.woff") format("woff"), /* Pretty Modern Browsers */
+        url("../fonts/BerlinTypeOffice-Bold.ttf")  format("truetype"); /* Safari, Android, iOS */
+
     font-weight: bold;
 }

--- a/digitalstrategie/assets/scss/components/_book.scss
+++ b/digitalstrategie/assets/scss/components/_book.scss
@@ -24,7 +24,7 @@
     font-size: $font-size-md;
     font-weight: bold;
     color: $white;
-    margin-bottom: 2*$spacer;
+    margin-bottom: 2 * $spacer;
 
     & a {
         color: $white;

--- a/digitalstrategie/assets/scss/components/_ds-block.scss
+++ b/digitalstrategie/assets/scss/components/_ds-block.scss
@@ -40,12 +40,12 @@
 }
 
 .ds-block {
-    padding-top: 5*$spacer;
-    padding-bottom: 5*$spacer;
+    padding-top: 5 * $spacer;
+    padding-bottom: 5 * $spacer;
 }
 
 .ds-block__row {
-    padding: 0 1*$spacer;
+    padding: 0 1 * $spacer;
 
     @media screen and (min-width: $breakpoint-md) {
         padding: 0;
@@ -54,7 +54,7 @@
 
 .ds-block__header_img {
     position: relative;
-    padding: 10*$spacer 0;
+    padding: 10 * $spacer 0;
 }
 
 .ds-block__header_img_overlay {
@@ -64,7 +64,7 @@
     top: 0;
     left: 0;
     right: 0;
-    background: rgba(255, 255, 255, 0);
+    background: rgba(255 255 255 0);
 }
 
 // FIXME: when we have more ds-blocks, they should get their own components
@@ -99,8 +99,7 @@
 .faq-ds-block__button {
     padding-left: 0;
     padding-right: 0;
-    border-radius: 0 !important; //overwrite of default bs
-
+    border-radius: 0 !important; // overwrite of default bs
     font-size: $h4-font-size;
     font-weight: $font-weight-bold;
 
@@ -175,7 +174,7 @@ img.textimg-ds-block__img {
 
 .teaser-ds-block-img__left img,
 .teaser-ds-block-img__right img {
-    display: block; //rm automatic whitespace from inline elements
+    display: block; // rm automatic whitespace from inline elements
 }
 
 .teaser-ds-block-img__left {

--- a/digitalstrategie/assets/scss/components/_menu.scss
+++ b/digitalstrategie/assets/scss/components/_menu.scss
@@ -8,6 +8,7 @@
 
     & button {
         @extend .btn--reset;
+
         color: $blue;
     }
 

--- a/digitalstrategie/assets/scss/style.scss
+++ b/digitalstrategie/assets/scss/style.scss
@@ -1,60 +1,67 @@
 // Required
 @import "~bootstrap/scss/functions";
 
-// Project specific values overwriting bootstrap's variable values
-@import 'variables';
+// Project specific values overwriting bootstrap"s variable values
+@import "variables";
+
 // Non-bootstrap project specific variables
-@import 'core-variables';
-@import 'base';
-@import 'fonts';
+@import "core-variables";
+@import "base";
+@import "fonts";
 
 // Must be loaded after above due to use of default
-@import '~bootstrap/scss/variables';
-@import '~bootstrap/scss/mixins';
-@import '~bootstrap/scss/utilities';
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/utilities";
 
 // Layout & components
-@import '~bootstrap/scss/root';
-// @import '~bootstrap/scss/reboot';
-// @import '~bootstrap/scss/type';
-// @import '~bootstrap/scss/images';
-@import '~bootstrap/scss/containers';
-@import '~bootstrap/scss/grid';
-// @import '~bootstrap/scss/tables';
-@import '~bootstrap/scss/forms';
-@import '~bootstrap/scss/buttons';
-@import '~bootstrap/scss/transitions';
-@import '~bootstrap/scss/dropdown';
-@import '~bootstrap/scss/button-group';
-@import '~bootstrap/scss/nav';
-@import '~bootstrap/scss/navbar';
-// @import '~bootstrap/scss/card';
-@import '~bootstrap/scss/accordion';
-@import '~bootstrap/scss/breadcrumb';
-// @import '~bootstrap/scss/pagination';
-// @import '~bootstrap/scss/badge';
-// @import '~bootstrap/scss/alert';
-// @import '~bootstrap/scss/progress';
-@import '~bootstrap/scss/list-group';
-@import '~bootstrap/scss/close';
-// @import '~bootstrap/scss/toasts';
-@import '~bootstrap/scss/modal';
-// @import '~bootstrap/scss/tooltip';
-// @import '~bootstrap/scss/popover';
-// @import '~bootstrap/scss/carousel';
-// @import '~bootstrap/scss/spinners';
-// @import '~bootstrap/scss/offcanvas';
+@import "~bootstrap/scss/root";
+
+// @import "~bootstrap/scss/reboot";
+// @import "~bootstrap/scss/type";
+// @import "~bootstrap/scss/images";
+@import "~bootstrap/scss/containers";
+@import "~bootstrap/scss/grid";
+
+// @import "~bootstrap/scss/tables";
+@import "~bootstrap/scss/forms";
+@import "~bootstrap/scss/buttons";
+@import "~bootstrap/scss/transitions";
+@import "~bootstrap/scss/dropdown";
+@import "~bootstrap/scss/button-group";
+@import "~bootstrap/scss/nav";
+@import "~bootstrap/scss/navbar";
+
+// @import "~bootstrap/scss/card";
+@import "~bootstrap/scss/accordion";
+@import "~bootstrap/scss/breadcrumb";
+
+// @import "~bootstrap/scss/pagination";
+// @import "~bootstrap/scss/badge";
+// @import "~bootstrap/scss/alert";
+// @import "~bootstrap/scss/progress";
+@import "~bootstrap/scss/list-group";
+@import "~bootstrap/scss/close";
+
+// @import "~bootstrap/scss/toasts";
+@import "~bootstrap/scss/modal";
+
+// @import "~bootstrap/scss/tooltip";
+// @import "~bootstrap/scss/popover";
+// @import "~bootstrap/scss/carousel";
+// @import "~bootstrap/scss/spinners";
+// @import "~bootstrap/scss/offcanvas";
 
 // Helpers
-@import '~bootstrap/scss/helpers';
+@import "~bootstrap/scss/helpers";
 
 // Utilities
-@import '~bootstrap/scss/utilities/api';
+@import "~bootstrap/scss/utilities/api";
 
-//Project components
-@import 'components/button';
-@import 'components/document';
-@import 'components/ds-block';
-@import 'components/footer';
-@import 'components/menu';
-@import 'components/book';
+// Project components
+@import "components/button";
+@import "components/document";
+@import "components/ds-block";
+@import "components/footer";
+@import "components/menu";
+@import "components/book";

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "husky": "7.0.4",
     "lint-staged": "11.2.4",
     "postcss": "8.3.11",
-    "stylelint": "13.13.1",
+    "stylelint": "14.0.0",
     "stylelint-config-standard": "23.0.0",
+    "stylelint-config-standard-scss": "2.0.0",
     "stylelint-declaration-strict-value": "1.7.12",
     "webpack-cli": "4.9.1"
   },
@@ -50,7 +51,7 @@
     "build:prod": "webpack --config webpack.prod.js --mode production",
     "build": "webpack --config webpack.dev.js --mode development",
     "watch": "webpack --config webpack.dev.js --watch --mode development",
-    "lint": "eslint digitalstrategie/assets --ext .js,.jsx && stylelint 'digitalstrategie/assets/scss/**/*.scss' --syntax scss",
+    "lint": "eslint digitalstrategie/assets --ext .js,.jsx && stylelint 'digitalstrategie/assets/scss/**/*.scss'",
     "lint-staged": "lint-staged",
     "lint-fix": "eslint --fix --ext .js,.jsx .",
     "postinstall": "husky install"


### PR DESCRIPTION
in order to make stylelint v14  work there were some adjustments to do:
- flag in linting command `--syntax scss` was omitted
- instead additional dependency `stylelint-config-standard-scss` is needed
- adjusting our files to a lot of new rules
- disabling some rules (maybe more to be disabled?)