### PR TITLE
forms/styling/validations: using CI validation errors

### DIFF
--- a/apps/forms/templates/apps_forms/includes/form.html
+++ b/apps/forms/templates/apps_forms/includes/form.html
@@ -6,7 +6,7 @@
     </div>
     <div class="row justify-content-center">
         <div class="col-lg-6 form--overwrite">
-            <form action="{% pageurl page %}" method="POST">
+            <form action="{% pageurl page %}" method="POST" novalidate>
                 <div class="form-group">
                     {% csrf_token %}
                     {% for field in form %}

--- a/apps/forms/templates/apps_forms/includes/form_field.html
+++ b/apps/forms/templates/apps_forms/includes/form_field.html
@@ -7,7 +7,7 @@
       {{ field.help_text }} {% if field.field.required %} *{% endif %}
     </label>
     {% if field.errors %}
-      <div class="alert alert-danger pb-0" role="alert">
+      <div class="message message--error" role="alert">
       {{ field.errors }}
       </div>
     {% endif %}
@@ -15,23 +15,27 @@
 {% elif field|is_checkbox_select_multiple %}
   <div class="form-group">
     <label class="mb-1">{{ field.help_text }} {% if field.field.required %} *{% endif %}</label>
-      {% render_field field %}
-    </label>
+    {% render_field field %}
     {% if field.errors %}
-      <div class="alert alert-danger pb-0" role="alert">
+      <div class="message message--error" role="alert">
       {{ field.errors }}
       </div>
     {% endif %}
   </div>
   <hr>
 {% else %}
-  <div class="form-group">
-    <label class="mb-1">{{ field.help_text }} {% if field.field.required %} *{% endif %}</label>
-    {% render_field field class="form-control" %}
-  </div>
-    {% if field.errors %}
-      <div class="alert alert-danger pb-0" role="alert">
+  {% if field.errors %}
+    <div class="form-group">
+      <label class="mb-1">{{ field.help_text }} {% if field.field.required %} *{% endif %}</label>
+      {% render_field field class="form-control is-invalid" %}
+    </div>
+    <div class="message message--error" role="alert">
       {{ field.errors }}
-      </div>
-    {% endif %}
+    </div>
+  {% else %}
+    <div class="form-group">
+      <label class="mb-1">{{ field.help_text }} {% if field.field.required %} *{% endif %}</label>
+      {% render_field field %}
+    </div>
+  {% endif %}
 {% endif %}

--- a/digitalstrategie/assets/scss/components/_form.scss
+++ b/digitalstrategie/assets/scss/components/_form.scss
@@ -12,7 +12,9 @@
     button.ui-multiselect,
     select,
     textarea {
-        border: solid 1px $text-gray;
+        &:not(.is-invalid):not(.is-valid) {
+            border: solid 1px $text-gray;
+        }
 
         &:focus {
             border-color: $blue;
@@ -59,8 +61,14 @@
         }
     }
 
-    .alert-danger {
-        color: $red;
-        background: rgba($red, 0.2);
+    .form-group + .message,
+    .form-group + .message--info,
+    .form-group + .message--success,
+    .form-group + .message--error,
+    .control-group + .message,
+    .control-group + .message--info,
+    .control-group + .message--success,
+    .control-group + .message--error {
+        margin-top: -1.25rem;
     }
 }


### PR DESCRIPTION
with this the validation errors looking how they should look according to CI/Design.

To mention is that the success case (greenbox, "Dieses Feld ist richtig ausgefüllt.") brings a bit of logic, idk at the moment how to deal with, because we do not send successful messages right? And we somehow do not want to show empty, not-required inputs as correctly filled in. And we do not want to show either errors, nor success on initial load of the form. Is this case even that important for now? @hmkay @mcastro-lqd what do you think?