### PR TITLE
images/logo: add width to svg for firefox

### DIFF
--- a/digitalstrategie/assets/images/logo.svg
+++ b/digitalstrategie/assets/images/logo.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg height="40" version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg height="40" width="280.25" version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 1985.98 283.46" style="enable-background:new 0 0 1985.98 283.46;" xml:space="preserve">
 <path d="M72.57,188.77h28.85c26.8,0,45.99-18.78,45.99-47.62c0-28.84-19.19-47.62-45.99-47.62H72.57c-0.95,0-1.63,0.68-1.63,1.63
 	v91.98C70.94,188.09,71.62,188.77,72.57,188.77z M87.54,110.13c0-0.54,0.41-0.82,0.82-0.82h11.29c15.51,0,30.21,8.03,30.21,31.84


### PR DESCRIPTION
so in the original logo it defined the size attributes which is why it worked without scss, the new one is just the vector without any attributes. I added height and it worked in chrome as it assumes the width but not in ff, in adding dimensions this logo will also work without css which is good as means we won't have to overwrite their header