### PR TITLE
Translations: added missing translations in participation form

### DIFF
--- a/apps/forms/templates/apps_forms/includes/form.html
+++ b/apps/forms/templates/apps_forms/includes/form.html
@@ -10,13 +10,7 @@
     <div class="ds-form__info-section">
         <p>*{% trans 'Required fields' %}</p>
         {% if page.remove_data_email %}
-            <p>
-                {% blocktrans with remove_email=page.remove_data_email %}
-                    If you wish to have your personal data deleted
-                    please write an e-mail to:
-                    <a href="mailto:{{ remove_email }}">{{ remove_email }}</a>
-                {% endblocktrans %}
-            </p>
+            <p>{% blocktrans with remove_email=page.remove_data_email %}If you wish to have your personal data deleted please write an e-mail to: <a href="mailto:{{ remove_email }}">{{ remove_email }}</a>{% endblocktrans %}</p>
         {% endif %}
     </div>
     <div class="form-actions">

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-10 13:45+0000\n"
+"POT-Creation-Date: 2022-02-21 09:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -101,28 +101,24 @@ msgstr ""
 msgid "I am interested in the following fields of action"
 msgstr "Ich habe Interesse an folgenden Handlungsfeldern"
 
-#: apps/forms/templates/apps_forms/form_page_landing.html:9
+#: apps/forms/templates/apps_forms/form_page_landing.html:8
 #, fuzzy
 #| msgid "Back to landing page"
 msgid "Back to Homepage"
 msgstr "Zurück zur Startseite"
 
-#: apps/forms/templates/apps_forms/includes/form.html:15
+#: apps/forms/templates/apps_forms/includes/form.html:11
 msgid "Required fields"
 msgstr ""
 
-#: apps/forms/templates/apps_forms/includes/form.html:18
+#: apps/forms/templates/apps_forms/includes/form.html:13
 #, python-format
 msgid ""
-"\n"
-"                                If you wish to have your personal data "
-"deleted\n"
-"                                please write an e-mail to:\n"
-"                                <span>%(remove_email)s</span>\n"
-"                            "
+"If you wish to have your personal data deleted please write an e-mail to: <a "
+"href=\"mailto:%(remove_email)s\">%(remove_email)s</a>"
 msgstr ""
 
-#: apps/forms/templates/apps_forms/includes/form.html:28
+#: apps/forms/templates/apps_forms/includes/form.html:18
 msgid "Send"
 msgstr "Senden"
 
@@ -197,9 +193,13 @@ msgstr "Zurück zur Startseite"
 msgid "Hello"
 msgstr "Hallo"
 
-#: digitalstrategie/templates/includes/footer.html:8
+#: digitalstrategie/templates/includes/footer.html:9
 msgid "To the top of the page"
 msgstr "Zum Seitenanfang"
+
+#: digitalstrategie/templates/includes/footer.html:10
+msgid "Related Links"
+msgstr ""
 
 #: digitalstrategie/templates/includes/header.html:9
 msgid "To the home page of Berlin.de"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -24,7 +24,7 @@ msgstr "Bitte füllen Sie dieses Feld aus."
 
 #: apps/forms/models.py:29
 msgid "to address"
-msgstr ""
+msgstr "An-Adresse"
 
 #: apps/forms/models.py:30
 msgid ""
@@ -36,7 +36,7 @@ msgstr ""
 
 #: apps/forms/models.py:34
 msgid "from address"
-msgstr ""
+msgstr "Von-Adresse"
 
 #: apps/forms/models.py:35
 msgid ""
@@ -47,7 +47,7 @@ msgstr ""
 
 #: apps/forms/models.py:39
 msgid "subject"
-msgstr ""
+msgstr "Betreff"
 
 #: apps/forms/models.py:40
 msgid ""
@@ -89,7 +89,7 @@ msgstr "Ihr Nachricht an uns..."
 msgid ""
 "The selected categories                     are displayed in the "
 "participation form."
-msgstr ""
+msgstr "Die ausgewählten Kategorien werden im Partizipationsformular dargestellt."
 
 #: apps/forms/models.py:244
 msgid "I agree that my contact data is stored"
@@ -109,7 +109,7 @@ msgstr "Zurück zur Startseite"
 
 #: apps/forms/templates/apps_forms/includes/form.html:11
 msgid "Required fields"
-msgstr ""
+msgstr "Pflichtfelder"
 
 #: apps/forms/templates/apps_forms/includes/form.html:13
 #, python-format
@@ -117,6 +117,8 @@ msgid ""
 "If you wish to have your personal data deleted please write an e-mail to: <a "
 "href=\"mailto:%(remove_email)s\">%(remove_email)s</a>"
 msgstr ""
+"Wenn Sie ihre personenbezogenen Daten löschen lassen möchten, kontaktieren Sie: "
+"<span>%(remove_email)s</span>"
 
 #: apps/forms/templates/apps_forms/includes/form.html:18
 msgid "Send"
@@ -150,7 +152,7 @@ msgstr "Vorherige Seite"
 
 #: apps/home/templates/apps_home/blocks/thesis_list_block.html:11
 msgid "Next slide"
-msgstr ""
+msgstr "Nächstes Bild"
 
 #: digitalstrategie/settings/base.py:120
 msgid "English"
@@ -199,7 +201,7 @@ msgstr "Zum Seitenanfang"
 
 #: digitalstrategie/templates/includes/footer.html:10
 msgid "Related Links"
-msgstr ""
+msgstr "Weiterführende Links"
 
 #: digitalstrategie/templates/includes/header.html:9
 msgid "To the home page of Berlin.de"

--- a/locale/de_ls/LC_MESSAGES/django.po
+++ b/locale/de_ls/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-10 13:45+0000\n"
+"POT-Creation-Date: 2022-02-21 09:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,26 +92,22 @@ msgstr ""
 msgid "I am interested in the following fields of action"
 msgstr ""
 
-#: apps/forms/templates/apps_forms/form_page_landing.html:9
+#: apps/forms/templates/apps_forms/form_page_landing.html:8
 msgid "Back to Homepage"
 msgstr ""
 
-#: apps/forms/templates/apps_forms/includes/form.html:15
+#: apps/forms/templates/apps_forms/includes/form.html:11
 msgid "Required fields"
 msgstr ""
 
-#: apps/forms/templates/apps_forms/includes/form.html:18
+#: apps/forms/templates/apps_forms/includes/form.html:13
 #, python-format
 msgid ""
-"\n"
-"                                If you wish to have your personal data "
-"deleted\n"
-"                                please write an e-mail to:\n"
-"                                <span>%(remove_email)s</span>\n"
-"                            "
+"If you wish to have your personal data deleted please write an e-mail to: <a "
+"href=\"mailto:%(remove_email)s\">%(remove_email)s</a>"
 msgstr ""
 
-#: apps/forms/templates/apps_forms/includes/form.html:28
+#: apps/forms/templates/apps_forms/includes/form.html:18
 msgid "Send"
 msgstr ""
 
@@ -184,8 +180,12 @@ msgstr ""
 msgid "Hello"
 msgstr ""
 
-#: digitalstrategie/templates/includes/footer.html:8
+#: digitalstrategie/templates/includes/footer.html:9
 msgid "To the top of the page"
+msgstr ""
+
+#: digitalstrategie/templates/includes/footer.html:10
+msgid "Related Links"
 msgstr ""
 
 #: digitalstrategie/templates/includes/header.html:9

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-10 13:45+0000\n"
+"POT-Creation-Date: 2022-02-21 09:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,25 +100,28 @@ msgstr "I agree that my contact data is stored"
 msgid "I am interested in the following fields of action"
 msgstr "I am interested in the following fields of action"
 
-#: apps/forms/templates/apps_forms/form_page_landing.html:9
+#: apps/forms/templates/apps_forms/form_page_landing.html:8
 #, fuzzy
 #| msgid "Back to landing page"
 msgid "Back to Homepage"
 msgstr "Back to landing page"
 
-#: apps/forms/templates/apps_forms/includes/form.html:15
+#: apps/forms/templates/apps_forms/includes/form.html:11
 msgid "Required fields"
 msgstr "Required fields"
 
-#: apps/forms/templates/apps_forms/includes/form.html:18
-#, python-format
+#: apps/forms/templates/apps_forms/includes/form.html:13
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "                                If you wish to have your personal data "
+#| "deleted\n"
+#| "                                please write an e-mail to:\n"
+#| "                                <span>%(remove_email)s</span>\n"
+#| "                            "
 msgid ""
-"\n"
-"                                If you wish to have your personal data "
-"deleted\n"
-"                                please write an e-mail to:\n"
-"                                <span>%(remove_email)s</span>\n"
-"                            "
+"If you wish to have your personal data deleted please write an e-mail to: <a "
+"href=\"mailto:%(remove_email)s\">%(remove_email)s</a>"
 msgstr ""
 "\n"
 "                                If you wish to have your personal data "
@@ -127,7 +130,7 @@ msgstr ""
 "                                <span>%(remove_email)s</span>\n"
 "                            "
 
-#: apps/forms/templates/apps_forms/includes/form.html:28
+#: apps/forms/templates/apps_forms/includes/form.html:18
 msgid "Send"
 msgstr "Send"
 
@@ -206,9 +209,13 @@ msgstr "Back to landing page"
 msgid "Hello"
 msgstr "Hello"
 
-#: digitalstrategie/templates/includes/footer.html:8
+#: digitalstrategie/templates/includes/footer.html:9
 msgid "To the top of the page"
 msgstr "To the top of the page"
+
+#: digitalstrategie/templates/includes/footer.html:10
+msgid "Related Links"
+msgstr "Related Links"
 
 #: digitalstrategie/templates/includes/header.html:9
 msgid "To the home page of Berlin.de"


### PR DESCRIPTION
Fixes #238
In the first commit, linebreaks were taken out of a blocktrans because these show up in the po-translation files.