### PR TITLE
Revert "Update elasticsearch from 7.17.0 to 8.1.0"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,4 @@ sentry-sdk==1.5.8
 wagtail==2.16.1
 whitenoise==6.0.0
 psycopg2-binary==2.9.3
-elasticsearch==8.1.0
+elasticsearch==7.17.0


### PR DESCRIPTION
This reverts commit 80ee2c0415c33420fb871dc227321f97634eb820.

As updating did break the search, reverting that!