### PR TITLE
apps/gruenbuch/detail-page: adding template for detailpage

### DIFF
--- a/apps/gruenbuch/models.py
+++ b/apps/gruenbuch/models.py
@@ -111,7 +111,7 @@ class GruenbuchOverviewPage(Page):
 
 
 class GruenbuchDetailPage(Page):
-    template = 'gruenbuch_page.html'
+    template = 'gruenbuch_detail_page.html'
 
     page_blocks = [
         ('paragraph', blocks.RichTextBlock()),

--- a/apps/gruenbuch/templates/gruenbuch_detail_page.html
+++ b/apps/gruenbuch/templates/gruenbuch_detail_page.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags wagtailimages_tags %}
+
+{% block content %}
+<div id="layout-grid__area--maincontent">
+  <h1>{{ page.page_title }}</h1>
+  {% if page.subtitle %}
+  <p>{{ page.subtitle }}</p>
+  {% endif %}
+  {% for block in self.body %}
+      {{ block }}
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
@sabinammm to mention is that currently the spacing around the FAQ block is quite big. changing this would affect all blocks so i leave it for now.