### PR TITLE
search: use partial_match to also mach prefixes

### DIFF
--- a/apps/gruenbuch/models.py
+++ b/apps/gruenbuch/models.py
@@ -101,12 +101,12 @@ class GruenbuchOverviewPage(Page):
     subpage_types = ['apps_gruenbuch.GruenbuchDetailPage']
 
     search_fields = Page.search_fields + [
-        index.SearchField('page_title_de'),
-        index.SearchField('page_title_en'),
-        index.SearchField('page_title_de_ls'),
-        index.SearchField('page_intro_de'),
-        index.SearchField('page_intro_en'),
-        index.SearchField('page_intro_de_ls'),
+        index.SearchField('page_title_de', partial_match=True),
+        index.SearchField('page_title_en', partial_match=True),
+        index.SearchField('page_title_de_ls', partial_match=True),
+        index.SearchField('page_intro_de', partial_match=True),
+        index.SearchField('page_intro_en', partial_match=True),
+        index.SearchField('page_intro_de_ls', partial_match=True),
     ]
 
 
@@ -178,13 +178,13 @@ class GruenbuchDetailPage(Page):
     ])
 
     search_fields = Page.search_fields + [
-        index.SearchField('page_title_de'),
-        index.SearchField('page_title_de_ls'),
-        index.SearchField('page_title_en'),
-        index.SearchField('subtitle_de'),
-        index.SearchField('subtitle_de_ls'),
-        index.SearchField('subtitle_en'),
-        index.SearchField('body_de'),
-        index.SearchField('body_de_ls'),
-        index.SearchField('body_en'),
+        index.SearchField('page_title_de', partial_match=True),
+        index.SearchField('page_title_de_ls', partial_match=True),
+        index.SearchField('page_title_en', partial_match=True),
+        index.SearchField('subtitle_de', partial_match=True),
+        index.SearchField('subtitle_de_ls', partial_match=True),
+        index.SearchField('subtitle_en', partial_match=True),
+        index.SearchField('body_de', partial_match=True),
+        index.SearchField('body_de_ls', partial_match=True),
+        index.SearchField('body_en', partial_match=True),
     ]

--- a/apps/home/models.py
+++ b/apps/home/models.py
@@ -105,15 +105,15 @@ class HomePage(Page):
                      'apps_forms.ParticipationFormPage']
 
     search_fields = Page.search_fields + [
-        index.SearchField('page_title_de'),
-        index.SearchField('page_title_en'),
-        index.SearchField('page_title_de_ls'),
-        index.SearchField('page_subtitle_de'),
-        index.SearchField('page_subtitle_en'),
-        index.SearchField('page_subtitle_de_ls'),
-        index.SearchField('body_de'),
-        index.SearchField('body_en'),
-        index.SearchField('body_de_ls')
+        index.SearchField('page_title_de', partial_match=True),
+        index.SearchField('page_title_en', partial_match=True),
+        index.SearchField('page_title_de_ls', partial_match=True),
+        index.SearchField('page_subtitle_de', partial_match=True),
+        index.SearchField('page_subtitle_en', partial_match=True),
+        index.SearchField('page_subtitle_de_ls', partial_match=True),
+        index.SearchField('body_de', partial_match=True),
+        index.SearchField('body_en', partial_match=True),
+        index.SearchField('body_de_ls', partial_match=True)
     ]
 
 
@@ -216,12 +216,12 @@ class OverviewPage(Page):
                      'apps_forms.ParticipationFormPage']
 
     search_fields = Page.search_fields + [
-        index.SearchField('page_title_de'),
-        index.SearchField('page_title_en'),
-        index.SearchField('page_title_de_ls'),
-        index.SearchField('page_intro_de'),
-        index.SearchField('page_intro_en'),
-        index.SearchField('page_intro_de_ls'),
+        index.SearchField('page_title_de', partial_match=True),
+        index.SearchField('page_title_en', partial_match=True),
+        index.SearchField('page_title_de_ls', partial_match=True),
+        index.SearchField('page_intro_de', partial_match=True),
+        index.SearchField('page_intro_en', partial_match=True),
+        index.SearchField('page_intro_de_ls', partial_match=True),
     ]
 
 
@@ -268,9 +268,9 @@ class DetailPage(Page):
     subpage_types = []
 
     search_fields = Page.search_fields + [
-        index.SearchField('body_de'),
-        index.SearchField('body_en'),
-        index.SearchField('body_de_ls')
+        index.SearchField('body_de', partial_match=True),
+        index.SearchField('body_en', partial_match=True),
+        index.SearchField('body_de_ls', partial_match=True)
     ]
 
 
@@ -331,7 +331,7 @@ class SimplePage(Page):
     subpage_types = []
 
     search_fields = Page.search_fields + [
-        index.SearchField('body_de'),
-        index.SearchField('body_en'),
-        index.SearchField('body_de_ls')
+        index.SearchField('body_de', partial_match=True),
+        index.SearchField('body_en', partial_match=True),
+        index.SearchField('body_de_ls', partial_match=True)
     ]


### PR DESCRIPTION
enable partial_match to also find prefixes (e.g. find ``berlin`` if you enter ``berli``)