### PR TITLE
templates/search: overwrite meta_tag block from base

### DIFF
--- a/digitalstrategie/templates/search_results.html
+++ b/digitalstrategie/templates/search_results.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags i18n %}
+
+{% block meta_tag %}
+    <title>{% trans 'Digital strategy - full-text search' %}</title>
+{% endblock %}
 
 {% block content %}
     <div class="layout-grid__area--maincontent">


### PR DESCRIPTION
I am pretty sure this will fix https://sentry.liqd.net/organizations/liqd/issues/2046/

I used a tiny part of the code we removed when adding the meta-tags. https://github.com/liqd/digitalstrategie/pull/346/files