### PR TITLE
assets/ds_block: fix top margin for coloured blocks on pages with hero

### DIFF
--- a/digitalstrategie/assets/scss/components/_ds-block-overwrites.scss
+++ b/digitalstrategie/assets/scss/components/_ds-block-overwrites.scss
@@ -23,7 +23,7 @@
     max-width: fit-content !important;
     background-color: $white;
     z-index: 1;
-    top: -15px;
+    top: -1px;
 
     p {
         margin-bottom: 0;

--- a/digitalstrategie/assets/scss/components/_ds-block.scss
+++ b/digitalstrategie/assets/scss/components/_ds-block.scss
@@ -10,9 +10,14 @@
     }
 }
 
-.ds-block--base {
+// needed for if non coloured blocks come straight after hero
+/* stylelint-disable */
+.ds-block--base,
+#layout-grid #layout-grid__area--maincontent > .ds-block--base {
     margin-top: 50px; // to be inline with styleguide
 }
+/* stylelint-enable */
+
 
 .ds-block {
     &--green,
@@ -99,7 +104,6 @@
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    margin: -$spacer;
 
     @media print, (min-width: 64.001rem) {
 

--- a/digitalstrategie/templates/includes/header.html
+++ b/digitalstrategie/templates/includes/header.html
@@ -1,6 +1,6 @@
 {% load snippet_tags i18n static %}
 {% load_site_menu "header" as header_menu_items %}
-<header id="header" class="kiekma">
+<header id="header">
 
     <!-- Portallogo Berlin Brand -->
     <div class="header__row-portalbrand">


### PR DESCRIPTION
when fixing spacing didn't check with all block types after header, this fixes if it's anon coloured block after the header