### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-11-09 12:35+0000\n"
-"PO-Revision-Date: 2022-11-08 15:47+0000\n"
-"Last-Translator: PhilliM <phillippamorland@gmail.com>\n"
-"Language-Team: German <https://trans.liqd.net/projects/gemeinsam-digital-"
-"berlin/main/de/>\n"
+"PO-Revision-Date: 2022-11-09 16:01+0000\n"
+"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
+"Language-Team: German <https://trans.liqd.net/projects/"
+"gemeinsam-digital-berlin/main/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,11 +21,11 @@ msgstr ""
 
 #: apps/captcha/fields.py:37 apps/captcha/fields.py:45
 msgid "Something about the answer to the captcha was wrong."
-msgstr ""
+msgstr "Etwas an der Antwort zum Captcha war falsch."
 
 #: apps/captcha/fields.py:50
 msgid "Your answer to the captcha was wrong."
-msgstr ""
+msgstr "Ihre Antwort zum Captcha war falsch."
 
 #: apps/contrib/django_standard_messages.py:6
 msgid "This field is required."
@@ -34,10 +34,11 @@ msgstr "Bitte füllen Sie dieses Feld aus."
 #: apps/forms/models.py:19
 msgid "If you are having difficulty please contact us by {}email{}."
 msgstr ""
+"Sollten Sie Schwierigkeiten haben, kontaktieren Sie uns gerne per  {}Email{}."
 
 #: apps/forms/models.py:35
 msgid "I am not a robot"
-msgstr ""
+msgstr "Ich bin kein Roboter."
 
 #: apps/forms/models.py:46
 msgid "to address"
@@ -87,6 +88,7 @@ msgid "Organisation"
 msgstr "Organisation"
 
 #: apps/forms/models.py:126
+#, fuzzy
 msgid "E-Mail"
 msgstr "Email"
 
@@ -110,6 +112,7 @@ msgstr ""
 "Die ausgewählten Kategorien werden im Partizipationsformular dargestellt."
 
 #: apps/forms/models.py:243
+#, fuzzy
 msgid "I agree that my contact data is stored"
 msgstr ""
 "Hiermit erkläre ich mich einverstanden, dass meine Kontaktdaten gespeichert "
@@ -128,7 +131,7 @@ msgid "Required fields"
 msgstr "Pflichtfelder"
 
 #: apps/forms/templates/apps_forms/includes/form.html:18
-#, python-format
+#, fuzzy, python-format
 msgid ""
 "If you wish to have your personal data deleted please write an e-mail to: <a "
 "href=\"mailto:%(remove_email)s\">%(remove_email)s</a>"
@@ -141,8 +144,9 @@ msgid "Send"
 msgstr "Senden"
 
 #: apps/forms/templates/apps_forms/includes/form_field.html:39
+#, fuzzy
 msgid "This field is required"
-msgstr ""
+msgstr "Dies ist ein Pflichtfeld."
 
 #: apps/gruenbuch/templates/gruenbuch_overview_page.html:34
 msgid "Downloads"
@@ -196,7 +200,7 @@ msgstr ""
 
 #: apps/home/templates/apps_home/blocks/video_block.html:27
 msgid ". For more information see"
-msgstr "übermittelt werden. Weitere Informationen finden Sie hier"
+msgstr "übermittelt werden. Weitere Informationen finden Sie in der"
 
 #: apps/home/templates/apps_home/blocks/video_block.html:31
 msgid "Data protection"
@@ -223,8 +227,9 @@ msgid "Video transcript"
 msgstr "Videoabschrift"
 
 #: apps/settings/helpers.py:8
+#, fuzzy
 msgid "Please look {}here{} for more information."
-msgstr ""
+msgstr "Weitere Informationen finden Sie {}hier{}."
 
 #: digitalstrategie/settings/base.py:124
 msgid "English"

--- a/locale/de/LC_MESSAGES/djangojs.po
+++ b/locale/de/LC_MESSAGES/djangojs.po
@@ -3,29 +3,30 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-11-09 12:35+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2022-11-09 16:01+0000\n"
+"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
+"Language-Team: German <https://trans.liqd.net/projects/"
+"gemeinsam-digital-berlin/js/de/>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.14.1\n"
 
 #: apps/captcha/assets/captcheck.js:29
 msgid "Image mode"
-msgstr ""
+msgstr "Bildmodus"
 
 #: apps/captcha/assets/captcheck.js:30
 msgid "Text mode"
-msgstr ""
+msgstr "Textmodus"
 
 #: apps/captcha/assets/captcheck.js:31
 msgid "Captcha: switch between image and text question"
-msgstr ""
+msgstr "Captcha: zwischen Bild- und Textfrage wechseln"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -3,20 +3,21 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-11-09 12:35+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2022-11-09 16:01+0000\n"
+"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
+"Language-Team: English <https://trans.liqd.net/projects/"
+"gemeinsam-digital-berlin/main/en/>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.14.1\n"
 
 #: apps/captcha/fields.py:37 apps/captcha/fields.py:45
 msgid "Something about the answer to the captcha was wrong."
@@ -130,7 +131,7 @@ msgid ""
 "If you wish to have your personal data deleted please write an e-mail to: <a "
 "href=\"mailto:%(remove_email)s\">%(remove_email)s</a>"
 msgstr ""
-"If you wish to have your personal data deleted please write an e-mail to: <a "
+"If you wish to have your personal data deleted, please write an email to: <a "
 "href=\"mailto:%(remove_email)s\">%(remove_email)s</a>"
 
 #: apps/forms/templates/apps_forms/includes/form.html:23


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://trans.liqd.net) for [Gemeinsam Digital: Berlin/main](https://trans.liqd.net/projects/gemeinsam-digital-berlin/main/).


It also includes following components:

* [Gemeinsam Digital: Berlin/js](https://trans.liqd.net/projects/gemeinsam-digital-berlin/js/)



Current translation status:

![Weblate translation status](https://trans.liqd.net/widgets/gemeinsam-digital-berlin/-/main/horizontal-auto.svg)