### PR TITLE
Revert "apps/contrib/meta tags: go to parent for meta tags until found"

### DIFF
--- a/apps/contrib/templatetags/custom_metadata_tags.py
+++ b/apps/contrib/templatetags/custom_metadata_tags.py
@@ -18,12 +18,11 @@ def custom_meta_tags(context, model=None):
         return ""
     if not model:
         model = context.get('self', None)
-        root = Site.find_for_request(request).root_page.specific
-        while not hasattr(model, 'get_meta_title') or (
-                not model.get_meta_title() and
+        if not hasattr(model, 'get_meta_title') or (
+                not model.meta_title and
                 not model.get_meta_description()):
-            if model == root:
-                return tags.meta_tags(request, model)
-            model = model.specific.get_parent().specific
+            site = Site.find_for_request(request)
+            if site:
+                model = site.root_page.specific
 
     return tags.meta_tags(request, model)


### PR DESCRIPTION
This reverts commit 9b4ea096de0aecdd1792ff5fd6fc7624104bb343.

It was this change after all. When I tried changing it to this directly on dev, it was still broken, but deploying a branch without this commit fixed it. :woman_shrugging: At least all the migrations aren't broken. :)