### PR TITLE
[7361] make metatags go through parents until metatags are found

### DIFF
--- a/apps/contrib/templatetags/custom_metadata_tags.py
+++ b/apps/contrib/templatetags/custom_metadata_tags.py
@@ -18,11 +18,13 @@ def custom_meta_tags(context, model=None):
         return ""
     if not model:
         model = context.get('self', None)
-        if not hasattr(model, 'get_meta_title') or (
-                not model.meta_title and
+        site = Site.find_for_request(request)
+        while not hasattr(model, 'get_meta_title') or (
+                not model.get_meta_title() and
                 not model.get_meta_description()):
-            site = Site.find_for_request(request)
-            if site:
+            if site and (not model or model == site.root_page.specific):
                 model = site.root_page.specific
+                break
+            model = model.specific.get_parent().specific
 
     return tags.meta_tags(request, model)

--- a/digitalstrategie/templates/search_results.html
+++ b/digitalstrategie/templates/search_results.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags i18n contrib_tags %}
 
-{% block meta_tag %}
-    <title>{% translate 'Gemeinsam Digital: Berlin - full-text search' %}</title>
-{% endblock %}
-
 {% block content %}
     <div class="layout-grid__area--maincontent">
         <div class="modul-headline">


### PR DESCRIPTION
redoes https://github.com/liqd/digitalstrategie/pull/771/files
But checks if the model does not exist which was the problem on the server. 