### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-12 10:37+0000\n"
-"PO-Revision-Date: 2023-06-08 12:47+0000\n"
-"Last-Translator: Max Westbrock <maxwestbrock@hotmail.com>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/gemeinsam-digital-"
-"berlin/main/de/>\n"
+"PO-Revision-Date: 2023-06-12 13:04+0000\n"
+"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/"
+"gemeinsam-digital-berlin/main/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -292,7 +292,7 @@ msgstr ""
 
 #: apps/home/blocks.py:10
 msgid "Your email address"
-msgstr ""
+msgstr "Deine Emailadresse"
 
 #: apps/home/blocks.py:12
 msgid ""
@@ -351,7 +351,7 @@ msgstr "Multiteaser (Spalten)"
 
 #: apps/home/blocks.py:232
 msgid "Icon Tiles"
-msgstr ""
+msgstr "Icon Tiles"
 
 #: apps/home/blocks.py:246
 msgid "Teaser Single"
@@ -372,7 +372,7 @@ msgstr "Nur Links zu Videos auf YouTube oder Vimeo können eingefügt werden."
 
 #: apps/home/blocks.py:285
 msgid "Add a preview image for the GDPR overlay."
-msgstr ""
+msgstr "Füge ein Vorschaubild für das DSGVO-Overlay hinzu."
 
 #: apps/home/blocks.py:288
 msgid "You can add the video's transcript here (unlimited characters)."
@@ -419,7 +419,7 @@ msgstr "Home Page Untertitel Leichte Sprache"
 
 #: apps/home/models.py:164 apps/home/models.py:428
 msgid "Intro image is not shown for Easy German"
-msgstr ""
+msgstr "Das Intro-Bild wird nicht für Leichte Sprache angezeigt"
 
 #: apps/home/models.py:175 apps/home/models.py:178 apps/home/models.py:181
 #: apps/home/models.py:439 apps/home/models.py:442 apps/home/models.py:445
@@ -522,7 +522,7 @@ msgstr "abgeschlossen"
 
 #: apps/measures/models.py:29
 msgid "citywide"
-msgstr ""
+msgstr "gesamtstädtisch"
 
 #: apps/measures/models.py:30
 msgid "Charlottenburg-Wilmersdorf"
@@ -715,7 +715,7 @@ msgstr "Mehr"
 #: apps/measures/templates/apps_measures/includes/measures_list_item.html:29
 msgctxt "For SRs, reads \"more about: <name of measure>\""
 msgid "about:"
-msgstr ""
+msgstr "über:"
 
 #: apps/measures/templates/apps_measures/measures_detail_page.html:10
 msgid "Responsible organisation"
@@ -842,6 +842,8 @@ msgid ""
 "These Links will be displayed as submenu items. Either in dropdowns or as "
 "items below a headline."
 msgstr ""
+"Diese Links werden als Untermenüelemente angezeigt. Entweder in Dropdowns "
+"oder als Elemente unterhalb einer Überschrift."
 
 #: apps/snippets/models.py:99
 msgid ""

--- a/locale/de/LC_MESSAGES/djangojs.po
+++ b/locale/de/LC_MESSAGES/djangojs.po
@@ -8,25 +8,25 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-12 10:37+0000\n"
-"PO-Revision-Date: 2022-11-09 16:01+0000\n"
+"PO-Revision-Date: 2023-06-12 13:10+0000\n"
 "Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
-"Language-Team: German <https://trans.liqd.net/projects/gemeinsam-digital-"
-"berlin/js/de/>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/"
+"gemeinsam-digital-berlin/js/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"X-Generator: Weblate 4.17\n"
 
 #: apps/captcha/assets/captcheck.js:29
 msgid "View image mode"
-msgstr ""
+msgstr "Bildmodus anzeigen"
 
 #: apps/captcha/assets/captcheck.js:30
 msgid "View text mode"
-msgstr ""
+msgstr "Textmodus anzeigen"
 
 #: apps/captcha/assets/captcheck.js:31
 msgid "Captcha, switch between image and text question"
-msgstr ""
+msgstr "Captcha, wechsle zwischen Bild- und Textfrage"

--- a/locale/de_ls/LC_MESSAGES/django.po
+++ b/locale/de_ls/LC_MESSAGES/django.po
@@ -3,45 +3,47 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-12 10:37+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-06-12 13:19+0000\n"
+"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/"
+"gemeinsam-digital-berlin/main/de_LS/>\n"
+"Language: de_ls\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.17\n"
 
 #: apps/captcha/fields.py:37 apps/captcha/fields.py:45
 msgid "Something about the answer to the captcha was wrong."
-msgstr ""
+msgstr "An deiner Antwort war etwas falsch."
 
 #: apps/captcha/fields.py:50
 msgid "Your answer to the captcha was wrong."
-msgstr ""
+msgstr "Deine Antwort war falsch."
 
 #: apps/captcha/templates/captcheck_captcha_widget.html:5
 #: apps/forms/models.py:36
 msgid "I am not a robot."
-msgstr ""
+msgstr "Ich bin kein Roboter."
 
 #: apps/captcha/templates/captcheck_captcha_widget.html:5
 #: apps/contrib/django_standard_messages.py:6
 msgid "This field is required."
-msgstr ""
+msgstr "In dieses Feld musst du etwas schreiben."
 
 #: apps/contrib/mixins.py:24
 msgid "Search image"
-msgstr ""
+msgstr "Suche Bild"
 
 #: apps/contrib/mixins.py:31
 msgid "Meta title de"
-msgstr ""
+msgstr "Meta-Titel de"
 
 #: apps/contrib/mixins.py:32
 msgid ""

--- a/locale/de_ls/LC_MESSAGES/djangojs.po
+++ b/locale/de_ls/LC_MESSAGES/djangojs.po
@@ -3,28 +3,30 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-12 10:37+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-06-12 13:19+0000\n"
+"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/"
+"gemeinsam-digital-berlin/js/de_LS/>\n"
+"Language: de_ls\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.17\n"
 
 #: apps/captcha/assets/captcheck.js:29
 msgid "View image mode"
-msgstr ""
+msgstr "Bild zeigen"
 
 #: apps/captcha/assets/captcheck.js:30
 msgid "View text mode"
-msgstr ""
+msgstr "Text zeigen"
 
 #: apps/captcha/assets/captcheck.js:31
 msgid "Captcha, switch between image and text question"
-msgstr ""
+msgstr "Captcha, hier kannst du zwischen Bild und Text wechseln"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [Gemeinsam Digital: Berlin/main](https://weblate.liqd.net/projects/gemeinsam-digital-berlin/main/).


It also includes following components:

* [Gemeinsam Digital: Berlin/js](https://weblate.liqd.net/projects/gemeinsam-digital-berlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widgets/gemeinsam-digital-berlin/-/main/horizontal-auto.svg)