### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-02 14:44+0000\n"
-"PO-Revision-Date: 2023-06-12 13:04+0000\n"
-"Last-Translator: maxliqd <m.westbrock@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/gemeinsam-digital-"
-"berlin/main/de/>\n"
+"POT-Creation-Date: 2023-10-31 13:25+0000\n"
+"PO-Revision-Date: 2023-11-02 15:19+0000\n"
+"Last-Translator: Julian Dehm <j.dehm@liqd.net>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/"
+"gemeinsam-digital-berlin/main/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -338,15 +338,15 @@ msgstr ""
 
 #: apps/home/blocks.py:141 apps/home/blocks.py:166
 msgid "Choose yellow, pink or purple to ensure CI conformity."
-msgstr ""
+msgstr "Wähle Gelb, Pink oder Lila um Konformität mit der CI zu gewährleisten."
 
 #: apps/home/blocks.py:148
 msgid "Coloured Teaser Centered"
-msgstr ""
+msgstr "Farbiger Teaser zentriert"
 
 #: apps/home/blocks.py:173
 msgid "Coloured Teaser Image"
-msgstr ""
+msgstr "Farbiger Teaser mit Bild"
 
 #: apps/home/blocks.py:195 apps/home/blocks.py:245
 msgid "Add either an external or internal link, not both"
@@ -358,7 +358,7 @@ msgstr "Füge nur diese Anzahl von Spalten unten hinzu"
 
 #: apps/home/blocks.py:212
 msgid "Teaser Image Multi"
-msgstr ""
+msgstr "Multiteaser mit Bild"
 
 #: apps/home/blocks.py:236
 msgid "Icon Tiles"
@@ -366,7 +366,7 @@ msgstr "Icon Tiles"
 
 #: apps/home/blocks.py:251
 msgid "Teaser Image Single"
-msgstr ""
+msgstr "Teaser mit Bild"
 
 #: apps/home/blocks.py:275
 msgid "This form only works with sendinblue"
@@ -617,7 +617,7 @@ msgstr "Smart Cities lernen gemeinsam"
 
 #: apps/measures/models.py:61
 msgid "Participatory Governance"
-msgstr ""
+msgstr "Partizipative Governance und Beteiligung"
 
 #: apps/measures/models.py:62
 msgid "Transparent Decision Processes"
@@ -745,7 +745,7 @@ msgstr "Status"
 
 #: apps/measures/templates/apps_measures/measures_detail_page.html:83
 msgid "Participation"
-msgstr "Partizipative Governance und Beteiligung"
+msgstr "Partizipation"
 
 #: apps/measures/templates/apps_measures/measures_detail_page.html:91
 msgid "Impact"
@@ -1070,7 +1070,13 @@ msgid_plural ""
 "            %(counter)s results.\n"
 "            "
 msgstr[0] ""
+"\n"
+"            %(counter)s Ergebnis.\n"
+"            "
 msgstr[1] ""
+"\n"
+"            %(counter)s Ergebnisse.\n"
+"            "
 
 #: digitalstrategie/templates/search_results.html:80
 msgid "No results found"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [Gemeinsam Digital: Berlin/main](https://weblate.liqd.net/projects/gemeinsam-digital-berlin/main/).


It also includes following components:

* [Gemeinsam Digital: Berlin/js](https://weblate.liqd.net/projects/gemeinsam-digital-berlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widgets/gemeinsam-digital-berlin/-/main/horizontal-auto.svg)